### PR TITLE
Move wgCreateWikiDatabase config to callback

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -6,6 +6,7 @@
 	"url": "https://github.com/miraheze/WikiDiscover",
 	"license-name": "AGPL-3.0-or-later",
 	"type": "specialpage",
+	"callback": "WikiDiscover::onRegistration",
 	"SpecialPages": {
 		"RandomWiki": "SpecialRandomWiki",
 		"WikiDiscover": "SpecialWikiDiscover"

--- a/extension.json
+++ b/extension.json
@@ -32,8 +32,7 @@
 		"@wgWikiDiscoverInactiveList": "A file with the list of all inactive wikis.",
 		"WikiDiscoverInactiveList": null,
 		"@wgWikiDiscoverPrivateList": "A file with the list of all private wikis.",
-		"WikiDiscoverPrivateList": null,
-		"CreateWikiDatabase": "metawiki"
+		"WikiDiscoverPrivateList": null
 	},
 	"manifest_version": 1
 }

--- a/includes/WikiDiscover.php
+++ b/includes/WikiDiscover.php
@@ -21,6 +21,13 @@ class WikiDiscover {
 		$this->inactive = array_map( 'trim', file( $wgWikiDiscoverInactiveList ) );
 	}
 
+	public static function onRegistration() {
+		global $wgCreateWikiDatabase;
+
+                if ( !isset( $wgCreateWikiDatabase ) ) {
+                        $wgCreateWikiDatabase = 'metawiki';
+                }
+	}
 
 	public function getCount() {
 		global $wgLocalDatabases;


### PR DESCRIPTION
Reason is in mw 1.31 you cannot specify this config in other extensions otherwise it fails with a hard failure.