### PR TITLE
Use the magic word value cache for magic word handlers

### DIFF
--- a/includes/WikiDiscover.php
+++ b/includes/WikiDiscover.php
@@ -113,7 +113,7 @@ class WikiDiscover {
 		$frame = null ) {
 		if ( $magicWordId == 'numberofwikis' ) {
 			global $wgLocalDatabases;
-			$ret = count( $wgLocalDatabases );
+			$ret = $cache[$magicWordId] = count( $wgLocalDatabases );
 		}
 		return true;
 	}


### PR DESCRIPTION
Deliberately uncached magic words are being deprecated; see I3d6b281f8e4e0bf68eefbf9767047527b4573b79.

Bug: T236813