### PR TITLE
Use the magic word value cache for magic word handlers

### DIFF
--- a/includes/WikiDiscover.php
+++ b/includes/WikiDiscover.php
@@ -98,22 +98,20 @@ class WikiDiscover {
 	}
 
 	/**
-	 * @param Parser &$parser
+	 * @param Parser $parser
 	 * @param array &$cache
-	 * @param string &$magicWordId
+	 * @param string $magicWordId
 	 * @param string &$ret
-	 * @param PPFrame|null $frame
 	 * @return bool true
 	 */
 	public static function onParserGetVariableValueSwitch(
-		Parser &$parser,
+		Parser $parser,
 		&$cache,
-		&$magicWordId,
-		&$ret,
-		$frame = null ) {
+		$magicWordId,
+		&$ret ) {
 		if ( $magicWordId == 'numberofwikis' ) {
 			global $wgLocalDatabases;
-			$ret = count( $wgLocalDatabases );
+			$ret = $cache[$magicWordId] = count( $wgLocalDatabases );
 		}
 		return true;
 	}


### PR DESCRIPTION
Deliberately uncached magic words are being deprecated; see I3d6b281f8e4e0bf68eefbf9767047527b4573b79.

Bug: T236813