### PR TITLE
Put WikiDiscoverAliases.php to Use

### DIFF
--- a/includes/WikiDiscoverAliases.php
+++ b/includes/WikiDiscoverAliases.php
@@ -6,3 +6,125 @@ $specialPageAliases['en'] = [
 	'RandomWiki' => [ 'RandomWiki' ],
 	'WikiDiscover' => [ 'WikiDiscover' ],
 ];
+
+// Translation aliases
+$specialPageAliases['ar'] = [
+	'RandomWiki' => [ 'ويكي عشوائي' ],
+	'WikiDiscover' => [ 'اكتشاف الويكي' ],
+];
+
+$specialPageAliases['ast'] = [
+	'RandomWiki' => [ 'Wiki al debalu' ],
+];
+
+$specialPageAliases['bn'] = [
+	'RandomWiki' => [ 'অজানা কোন উইকি' ],
+	'WikiDiscover' => [ 'উইকিডিস্কোভার' ],
+];
+
+$specialPageAliases['da'] = [
+	'RandomWiki' => [ 'Tilfældig Wiki' ],
+];
+
+$specialPageAliases['de'] = [
+	'RandomWiki' => [ 'Zufälliges Wiki'],
+	'WikiDiscover' => [ 'Wikientdeckung' ],
+];
+
+$specialPageAliases['el'] = [
+	'RandomWiki' => [ 'Τυχαίο βίκι' ],
+];
+
+$specialPageAliases['eo'] = [
+	'RandomWiki' => [ 'Hazarda Vikio' ],
+];
+
+$specialPageAliases['es'] = [
+	'RandomWiki' => [ 'Wiki al azar' ],
+];
+
+$specialPageAliases['fa'] = [
+	'RandomWiki' => ['ویکی تصادفی' ],
+];
+
+$specialPageAliases['fr'] = [
+	'RandomWiki' => [ 'Wiki aléatoire' ],
+];
+
+$specialPageAliases['gl'] = [
+	'RandomWiki' => [ 'Wiki aleatoria' ],
+	'WikiDiscover' => [ 'WikiDescuberta' ],
+];
+
+$specialPageAliases['he'] = [
+	'RandomWiki' => [ 'אתר ויקי אקראי' ],
+	'WikiDiscover' => [ 'גילוי אתרי ויקי' ],
+];
+
+$specialPageAliases['ko'] = [
+	'RandomWiki' => [ '임의의 위키로' ],
+];
+
+$specialPageAliases['lb'] = [
+	'RandomWiki' => [ 'Zoufälleg Wiki' ],
+];
+
+$specialPageAliases['mk'] = [
+	'RandomWiki' => [ 'Случајно вики' ],
+	'WikiDiscover' => [ 'Викиоткривање' ],
+];
+
+$specialPageAliases['nb'] = [
+	'RandomWiki' => [ 'Tilfeldig wiki' ],
+	'WikiDiscover' => [ 'Wikioppdager' ],
+];
+
+$specialPageAliases['nl'] = [
+	'RandomWiki' => [ 'Willekeurige Wiki' ],
+];
+
+$specialPageAliases['pl'] = [
+	'RandomWiki' => [ 'Losowa wiki' ],
+	'WikiDiscover' => [ 'Odkrywaj wiki' ],
+];
+
+$specialPageAliases['pt-br'] = [
+	'RandomWiki' => [ 'Wiki aleatória' ],
+	'WikiDiscover' => [ 'WikiDescoberta' ],
+];
+
+$specialPageAliases['pt'] = [
+	'RandomWiki' => [ 'Wiki aleatória' ],
+	'WikiDiscover' => [ 'WikiDescoberta' ],
+];
+
+$specialPageAliases['roa-tara'] = [
+	'RandomWiki' => [ 'Uicchi a uecchije' ],
+	'WikiDiscover' => [ 'UicchiScuperte' ],
+];
+
+$specialPageAliases['ru'] = [
+	// RU has "/n"s in front of this string which have been omitted.
+	'RandomWiki' => [ 'Случайная Вики' ],
+];
+
+$specialPageAliases['sv'] = [
+	'RandomWiki' => [ 'Slumpwiki' ],
+];
+
+$specialPageAliases['tr'] = [
+	'RandomWiki' => [ 'Rastgele Viki' ],
+];
+
+$specialPageAliases['uk'] = [
+	'RandomWiki' => [ 'Випадкова вікі' ],
+];
+
+
+$specialPageAliases['zh-hans'] = [
+	'RandomWiki' => [ 'Випадкова вікі' ],
+];
+
+$specialPageAliases['zh-hant'] = [
+	'RandomWiki' => [ '隨機 wiki' ],
+];


### PR DESCRIPTION
There is no reason of having it if you do not add translations to it. All translations have been copied from ``i18n/lang.json``. I have skipped "translations" which were the same as English special page names as that is just redundant.