### PR TITLE
Change the default sorting criteria from dbname to creation

### DIFF
--- a/includes/WikiDiscoverWikisPager.php
+++ b/includes/WikiDiscoverWikisPager.php
@@ -166,7 +166,7 @@ class WikiDiscoverWikisPager extends TablePager {
 	}
 
 	public function getDefaultSort() {
-		return 'wiki_dbname';
+		return 'wiki_creation';
 	}
 
 	public function isFieldSortable( $name ) {


### PR DESCRIPTION
I think it doesn't make sense to sort wikis by `wiki_dbname` alphabetically. because:

- There are so many wikis, so it is not possible to manually look up a wiki by turning pages one by one.
- The `dbname` is not the displaying name of the wiki. So sorting by `dbname` could result in random order, at least to the user using web UI.

I pick the `wiki_creation` as the sorting criteria because I think it is only possible a linear column. Then the page shows the oldest wiki first (or newest first? I haven't inspected it) and it makes some context than `db_name`.