### PR TITLE
API: extend ApiQueryBase and add PHPUnit test

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -2,7 +2,7 @@
 
 $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
 
-$cfg['minimum_target_php_version'] = '8.0';
+$cfg['minimum_target_php_version'] = '8.1';
 
 $cfg['directory_list'] = array_merge(
 	$cfg['directory_list'], [

--- a/extension.json
+++ b/extension.json
@@ -47,13 +47,13 @@
 	},
 	"Hooks": {
 		"ParserFirstCallInit": [
-			"Miraheze\\WikiDiscover\\WikiDiscover::onParserFirstCallInit"
+			"Miraheze\\WikiDiscover\\Hooks::onParserFirstCallInit"
 		],
 		"ParserGetVariableValueSwitch": [
-			"Miraheze\\WikiDiscover\\WikiDiscover::onParserGetVariableValueSwitch"
+			"Miraheze\\WikiDiscover\\Hooks::onParserGetVariableValueSwitch"
 		],
 		"GetMagicVariableIDs": [
-			"Miraheze\\WikiDiscover\\WikiDiscover::onGetMagicVariableIDs"
+			"Miraheze\\WikiDiscover\\Hooks::onGetMagicVariableIDs"
 		]
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -15,7 +15,7 @@
 			"CreateWiki": "*"
 		},
 		"platform": {
-			"php": ">= 8.0"
+			"php": ">= 8.1"
 		}
 	},
 	"SpecialPages": {
@@ -23,7 +23,12 @@
 		"WikiDiscover": "Miraheze\\WikiDiscover\\Specials\\SpecialWikiDiscover"
 	},
 	"APIListModules": {
-		"wikidiscover": "Miraheze\\WikiDiscover\\Api\\ApiQueryWikiDiscover"
+		"wikidiscover": {
+			"class": "Miraheze\\WikiDiscover\\Api\\ApiQueryWikiDiscover",
+			"services": [
+				"CreateWikiDatabaseUtils"
+			]
+		}
 	},
 	"MessagesDirs": {
 		"WikiDiscover": [

--- a/extension.json
+++ b/extension.json
@@ -27,6 +27,7 @@
 			"class": "Miraheze\\WikiDiscover\\Api\\ApiQueryWikiDiscover",
 			"services": [
 				"CreateWikiDatabaseUtils",
+				"CreateWikiValidator",
 				"ExtensionRegistry",
 				"LanguageNameUtils"
 			]

--- a/extension.json
+++ b/extension.json
@@ -27,7 +27,8 @@
 			"class": "Miraheze\\WikiDiscover\\Api\\ApiQueryWikiDiscover",
 			"services": [
 				"CreateWikiDatabaseUtils",
-				"ExtensionRegistry"
+				"ExtensionRegistry",
+				"LanguageNameUtils"
 			]
 		}
 	},

--- a/extension.json
+++ b/extension.json
@@ -13,6 +13,9 @@
 		"MediaWiki": ">= 1.43.0",
 		"extensions": {
 			"CreateWiki": "*"
+		},
+		"platform": {
+			"php": ">= 8.0"
 		}
 	},
 	"SpecialPages": {

--- a/extension.json
+++ b/extension.json
@@ -26,7 +26,8 @@
 		"wikidiscover": {
 			"class": "Miraheze\\WikiDiscover\\Api\\ApiQueryWikiDiscover",
 			"services": [
-				"CreateWikiDatabaseUtils"
+				"CreateWikiDatabaseUtils",
+				"ExtensionRegistry"
 			]
 		}
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,15 @@
 			"R4356th"
 		]
 	},
+	"apihelp-query+wikidiscover-example": "Show all wikis on the form.",
+	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
+	"apihelp-query+wikidiscover-param-customurl": "Filter by if the wiki has a CreateWiki defined custom URL.",
+	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
+	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
+	"apihelp-query+wikidiscover-param-prop": "Information to return about a defined wiki.",
+	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
+	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
+	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
 	"randomwiki": "Redirect to a random wiki",
 	"randomwiki-header": "Choose a category and language below and on submission, you will redirected to a random wiki which meets the criteria selected.",
 	"randomwiki-parameters": "Select parameters",
@@ -19,13 +28,5 @@
 	"wikidiscover-table-language": "Language",
 	"wikidiscover-table-state": "State",
 	"wikidiscover-table-visibility": "Visibility",
-	"wikidiscover-table-wiki": "Wiki name",
-	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
-	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
-	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
-	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
-	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
-	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
-	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
-	"apihelp-query+wikidiscover-example": "Show all wikis on the form."
+	"wikidiscover-table-wiki": "Wiki name"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -21,6 +21,8 @@
 	"wikidiscover-table-visibility": "Visibility",
 	"wikidiscover-table-wiki": "Wiki name",
 	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
+	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
+	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
 	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
 	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
 	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -26,6 +26,6 @@
 	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
 	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
 	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
-	"apihelp-query+wikidiscover-param-wikislist": "Get a list of all wikis.",
+	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
 	"apihelp-query+wikidiscover-example": "Show all wikis on the form."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -21,6 +21,8 @@
 	"wikidiscover-table-visibility": "Label for 'Visibility'",
 	"wikidiscover-table-wiki": "Label for 'Wiki Name'",
 	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
+	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
+	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
 	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
 	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
 	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -26,6 +26,6 @@
 	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
 	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
 	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
-	"apihelp-query+wikidiscover-param-wikislist": "Get a list of all wikis.",
+	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
 	"apihelp-query+wikidiscover-example": "Show all wikis on the form."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,6 +6,15 @@
 			"Universal Omega"
 		]
 	},
+	"apihelp-query+wikidiscover-example": "Show all wikis on the form.",
+	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
+	"apihelp-query+wikidiscover-param-customurl": "Filter by if the wiki has a CreateWiki defined custom URL.",
+	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
+	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
+	"apihelp-query+wikidiscover-param-prop": "Information to return about a defined wiki.",
+	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
+	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
+	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
 	"randomwiki": "Page title for Special:RandomWiki",
 	"randomwiki-header": "Information text under legend header informing users what the page does.",
 	"randomwiki-parameters": "Legend header in Special:RandomWiki asking users to insert parameters for their search.",
@@ -19,13 +28,5 @@
 	"wikidiscover-table-language": "Label for 'Language'\n{{Identical|Language}}",
 	"wikidiscover-table-state": "Label for 'State'\n{{Identical|State}}",
 	"wikidiscover-table-visibility": "Label for 'Visibility'",
-	"wikidiscover-table-wiki": "Label for 'Wiki Name'",
-	"apihelp-query+wikidiscover-summary": "Get a list of wikis on a CreateWiki wikifarm.",
-	"apihelp-query+wikidiscover-param-category": "Filter by the CreateWiki defined category of a wiki.",
-	"apihelp-query+wikidiscover-param-language": "Filter by the CreateWiki defined language code of a wiki.",
-	"apihelp-query+wikidiscover-param-state": "Filter by the CreateWiki defined state of a wiki.",
-	"apihelp-query+wikidiscover-param-siteprop": "Information to return about a defined wiki.",
-	"apihelp-query+wikidiscover-param-limit": "Maximum number of results to show.",
-	"apihelp-query+wikidiscover-param-wikis": "Get a list of specific wikis.",
-	"apihelp-query+wikidiscover-example": "Show all wikis on the form."
+	"wikidiscover-table-wiki": "Label for 'Wiki Name'"
 }

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -8,7 +8,6 @@ use MediaWiki\Api\ApiQueryBase;
 use MediaWiki\Api\ApiResult;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
-use MediaWiki\SiteStats\SiteStatsInit;
 use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
 use Miraheze\CreateWiki\Services\CreateWikiValidator;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
@@ -234,14 +233,6 @@ class ApiQueryWikiDiscover extends ApiQueryBase {
 				$wiki['locked'] = true;
 			}
 
-			// This can be expensive so only allow showing up to 100 at a time.
-			if ( $limit <= 100 && in_array( 'editcount', $prop ) ) {
-				$dbr = $this->databaseUtils->getRemoteWikiReplicaDB( $wiki['dbname'] );
-				$counter = new SiteStatsInit( $dbr );
-
-				$wiki['editcount'] = $counter->edits();
-			}
-
 			$fit = $result->addValue( [ 'query', $this->getModuleName(), 'wikis' ], $row->wiki_dbname, $wiki );
 			if ( !$fit ) {
 				$this->setContinueEnumParameter( 'offset', $offset + $count - 1 );
@@ -299,7 +290,6 @@ class ApiQueryWikiDiscover extends ApiQueryBase {
 					'creationdate',
 					'description',
 					'deletiondate',
-					'editcount',
 					'exemptreason',
 					'inactivedate',
 					'languagecode',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -140,16 +140,16 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['url'] = $url;
 			}
 
-			if ( in_array( 'category', $siteprop ) ) {
-				$wiki['dbname'] = $row->wiki_category;
-			}
-
 			if ( in_array( 'dbname', $siteprop ) ) {
 				$wiki['dbname'] = $row->wiki_dbname;
 			}
 
 			if ( in_array( 'sitename', $siteprop ) ) {
 				$wiki['sitename'] = $row->wiki_sitename;
+			}
+
+			if ( in_array( 'category', $siteprop ) ) {
+				$wiki['category'] = $row->wiki_category;
 			}
 
 			if ( in_array( 'languagecode', $siteprop ) ) {

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -130,7 +130,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
 		$this->addWhereIf(
 			$this->getDB()->expr( 'wiki_url', '!=', null ),
-			$params['customurl']
+			$params['customurl'] === true
 		);
 
 		$this->addFieldsIf( 'wiki_category', in_array( 'category', $prop ) );

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -3,9 +3,8 @@
 namespace Miraheze\WikiDiscover\Api;
 
 use MediaWiki\Api\ApiBase;
-use MediaWiki\Api\ApiPageSet;
 use MediaWiki\Api\ApiQuery;
-use MediaWiki\Api\ApiQueryGeneratorBase;
+use MediaWiki\Api\ApiQueryBase;
 use MediaWiki\Api\ApiResult;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
@@ -17,7 +16,7 @@ use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 use Wikimedia\Rdbms\IReadableDatabase;
 
-class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
+class ApiQueryWikiDiscover extends ApiQueryBase {
 
 	public function __construct(
 		ApiQuery $query,
@@ -31,24 +30,6 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 	}
 
 	public function execute(): void {
-		$this->run( null );
-	}
-
-	/** @inheritDoc */
-	public function getCacheMode( $params ): string {
-		return 'public';
-	}
-
-	/** @inheritDoc */
-	public function executeGenerator( $resultPageSet ): void {
-		$this->run( $resultPageSet );
-	}
-
-	protected function getDB(): IReadableDatabase {
-		return $this->databaseUtils->getGlobalReplicaDB();
-	}
-
-	private function run( ?ApiPageSet $resultPageSet ): void {
 		$params = $this->extractRequestParams();
 		$result = $this->getResult();
 
@@ -272,6 +253,15 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			[ 'query', $this->getModuleName() ], 'count', $count,
 			ApiResult::ADD_ON_TOP | ApiResult::NO_SIZE_CHECK
 		);
+	}
+	
+	/** @inheritDoc */
+	public function getCacheMode( $params ): string {
+		return 'public';
+	}
+
+	protected function getDB(): IReadableDatabase {
+		return $this->databaseUtils->getGlobalReplicaDB();
 	}
 
 	/** @inheritDoc */

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -63,19 +63,14 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		}
 
 		if ( $language ) {
-			$isLanguageInvalid = count(
-				array_filter(
-					$language,
-					fn ( string $code ): bool => !$this->languageNameUtils->isSupportedLanguage( $code )
-				)
-			) > 0;
-
-			if ( $isLanguageInvalid ) {
-				$encodedLanguage = $this->encodeParamName( 'language' );
-				$this->dieWithError(
-					[ 'apierror-invalidlang', $encodedLanguage ],
-					'invalidlanguage'
-				);
+			foreach ( $language as $code ) {
+				if ( !$this->languageNameUtils->isSupportedLanguage( $code ) ) {
+					$encodedLanguage = $this->encodeParamName( 'language' );
+					$this->dieWithError(
+						[ 'apierror-invalidlang', $encodedLanguage ],
+						'invalidlanguage'
+					);
+				}
 			}
 
 			$this->addWhereFld( 'wiki_language', $language );

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -92,8 +92,16 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				);
 			}
 
+			if ( in_array( 'open', $state ) ) {
+				$this->addWhere( 'wiki_closed = 0 AND wiki_deleted = 0' );
+			}
+
 			if ( in_array( 'locked', $state ) ) {
 				$this->addWhereFld( 'wiki_locked', 1 );
+			}
+
+			if ( in_array( 'unlocked', $state ) ) {
+				$this->addWhereFld( 'wiki_locked', 0 );
 			}
 
 			if ( in_array( 'private', $state ) ) {
@@ -252,8 +260,10 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 					'deleted',
 					'inactive',
 					'locked',
+					'open',
 					'private',
 					'public',
+					'unlocked',
 				],
 			],
 			'siteprop' => [

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -177,7 +177,6 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				break;
 			}
 		}
-
 	}
 
 	/** @inheritDoc */

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -98,7 +98,6 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
 		$this->addFieldsIf( 'wiki_category', in_array( 'category', $siteprop ) );
 		$this->addFieldsIf( 'wiki_creation', in_array( 'creation', $siteprop ) );
-		$this->addFieldsIf( 'wiki_dbname', in_array( 'dbname', $siteprop ) );
 		$this->addFieldsIf( 'wiki_language', in_array( 'languagecode', $siteprop ) );
 		$this->addFieldsIf( 'wiki_sitename', in_array( 'sitename', $siteprop ) );
 		$this->addFieldsIf( 'wiki_url', in_array( 'url', $siteprop ) );
@@ -108,6 +107,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
 		$this->addFields( [
 			'wiki_closed',
+			'wiki_dbname',
 			'wiki_deleted',
 			'wiki_inactive',
 			'wiki_locked',
@@ -207,7 +207,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['locked'] = true;
 			}
 
-			$fit = $result->addValue( [ 'query', $this->getModuleName() ], null, $wiki );
+			$fit = $result->addValue( [ 'query', $this->getModuleName(), $row->wiki_dbname ], null, $wiki );
 			if ( !$fit ) {
 				$this->setContinueEnumParameter( 'offset', $offset + $count - 1 );
 				break;
@@ -247,7 +247,6 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 					'category',
 					'closure',
 					'creation',
-					'dbname',
 					'description',
 					'deletion',
 					'languagecode',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -6,6 +6,7 @@ use MediaWiki\Api\ApiBase;
 use MediaWiki\Api\ApiPageSet;
 use MediaWiki\Api\ApiQuery;
 use MediaWiki\Api\ApiQueryGeneratorBase;
+use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
 use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
@@ -19,7 +20,8 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		ApiQuery $query,
 		string $moduleName,
 		private readonly CreateWikiDatabaseUtils $databaseUtils,
-		private readonly ExtensionRegistry $extensionRegistry
+		private readonly ExtensionRegistry $extensionRegistry,
+		private readonly LanguageNameUtils $languageNameUtils
 	) {
 		parent::__construct( $query, $moduleName, 'wd' );
 	}
@@ -61,6 +63,14 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		}
 
 		if ( $language ) {
+			if ( !$this->languageNameUtils->isValidCode( $language ) ) {
+				$encodedLanguage = $this->encodeParamName( 'language' );
+				$this->dieWithError(
+					[ 'apierror-invalidlang', $encodedLanguage ],
+					'invalidlanguage'
+				);
+			}
+
 			$this->addWhereFld( 'wiki_language', $language );
 		}
 

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -254,7 +254,7 @@ class ApiQueryWikiDiscover extends ApiQueryBase {
 			ApiResult::ADD_ON_TOP | ApiResult::NO_SIZE_CHECK
 		);
 	}
-	
+
 	/** @inheritDoc */
 	public function getCacheMode( $params ): string {
 		return 'public';

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -66,7 +66,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			$isLanguageInvalid = count(
 				array_filter(
 					$language,
-					fn ( string $code ): bool => !$this->languageNameUtils->isValidCode( $code )
+					fn ( string $code ): bool => !$this->languageNameUtils->isSupportedLanguage( $code )
 				)
 			) > 0;
 

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -6,14 +6,18 @@ use MediaWiki\Api\ApiBase;
 use MediaWiki\Api\ApiPageSet;
 use MediaWiki\Api\ApiQuery;
 use MediaWiki\Api\ApiQueryGeneratorBase;
-use MediaWiki\MediaWikiServices;
+use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
 use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
 use Wikimedia\Rdbms\IReadableDatabase;
 
 class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
-	public function __construct( ApiQuery $query, string $moduleName ) {
+	public function __construct(
+		ApiQuery $query,
+		string $moduleName,
+		private readonly CreateWikiDatabaseUtils $databaseUtils
+	) {
 		parent::__construct( $query, $moduleName, 'wd' );
 	}
 
@@ -32,8 +36,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 	}
 
 	protected function getDB(): IReadableDatabase {
-		$connectionProvider = MediaWikiServices::getInstance()->getConnectionProvider();
-		return $connectionProvider->getReplicaDatabase( 'virtual-createwiki' );
+		return $this->databaseUtils->getGlobalReplicaDB();
 	}
 
 	private function run( ?ApiPageSet $resultPageSet ): void {

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -147,13 +147,11 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['url'] = $url;
 			}
 
-			if ( in_array( 'dbname', $siteprop ) ) {
-				$wiki['dbname'] = $row->wiki_dbname;
-				if ( in_array( 'description', $siteprop ) ) {
-					if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
-						$manageWikiSettings = new ManageWikiSettings( $wiki['dbname'] );
-						$wiki['description'] = $manageWikiSettings->list( 'wgWikiDiscoverDescription' );
-					}
+			$wiki['dbname'] = $row->wiki_dbname;
+			if ( in_array( 'description', $siteprop ) ) {
+				if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
+					$manageWikiSettings = new ManageWikiSettings( $wiki['dbname'] );
+					$wiki['description'] = $manageWikiSettings->list( 'wgWikiDiscoverDescription' );
 				}
 			}
 

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -231,7 +231,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 						$reason = $row->wiki_inactive_exempt_reason;
 						if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
 							$options = $this->getConfig()->get( 'ManageWikiInactiveExemptReasonOptions' );
-							$reason = $options[$reason] ?? $reason;
+							$reason = array_flip( $options )[$reason] ?? $reason;
 						}
 						$wiki['exempt-reason'] = $reason;
 					}

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -130,17 +130,18 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
 		$this->addWhereIf(
 			$this->getDB()->expr( 'wiki_url', '!=', null ),
-			$params['customurl'] === true
+			$params['customurl']
 		);
 
 		$this->addFieldsIf( 'wiki_category', in_array( 'category', $prop ) );
-		$this->addFieldsIf( 'wiki_creation', in_array( 'creation', $prop ) );
+		$this->addFieldsIf( 'wiki_creation', in_array( 'creationdate', $prop ) );
 		$this->addFieldsIf( 'wiki_language', in_array( 'languagecode', $prop ) );
 		$this->addFieldsIf( 'wiki_sitename', in_array( 'sitename', $prop ) );
 		$this->addFieldsIf( 'wiki_url', in_array( 'url', $prop ) );
 
-		$this->addFieldsIf( 'wiki_closed_timestamp', in_array( 'closure', $prop ) );
-		$this->addFieldsIf( 'wiki_deleted_timestamp', in_array( 'deletion', $prop ) );
+		$this->addFieldsIf( 'wiki_closed_timestamp', in_array( 'closuredate', $prop ) );
+		$this->addFieldsIf( 'wiki_deleted_timestamp', in_array( 'deletiondate', $prop ) );
+		$this->addFieldsIf( 'wiki_inactive_timestamp', in_array( 'inactivedate', $prop ) );
 
 		$this->addFieldsIf( 'wiki_inactive_exempt_reason', in_array( 'exemptreason', $prop ) );
 
@@ -198,8 +199,8 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['languagecode'] = $row->wiki_language;
 			}
 
-			if ( in_array( 'creation', $prop ) ) {
-				$wiki['creation'] = wfTimestamp( TS_ISO_8601, $row->wiki_creation );
+			if ( in_array( 'creationdate', $prop ) ) {
+				$wiki['creationdate'] = wfTimestamp( TS_ISO_8601, $row->wiki_creation );
 			}
 
 			$wikiState = match ( true ) {
@@ -212,20 +213,23 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			switch ( true ) {
 				case $row->wiki_deleted:
 					$wiki['deleted'] = true;
-					if ( in_array( 'deletion', $prop ) ) {
-						$wiki['deletion'] = wfTimestamp( TS_ISO_8601, $row->wiki_deleted_timestamp );
+					if ( in_array( 'deletiondate', $prop ) ) {
+						$wiki['deletiondate'] = wfTimestamp( TS_ISO_8601, $row->wiki_deleted_timestamp );
 					}
 					break;
 
 				case $row->wiki_closed:
 					$wiki['closed'] = true;
-					if ( in_array( 'closure', $prop ) ) {
-						$wiki['closure'] = wfTimestamp( TS_ISO_8601, $row->wiki_closed_timestamp );
+					if ( in_array( 'closuredate', $prop ) ) {
+						$wiki['closuredate'] = wfTimestamp( TS_ISO_8601, $row->wiki_closed_timestamp );
 					}
 					break;
 
 				case $row->wiki_inactive:
 					$wiki['inactive'] = true;
+					if ( in_array( 'inactivedate', $prop ) ) {
+						$wiki['inactivedate'] = wfTimestamp( TS_ISO_8601, $row->wiki_inactive_timestamp );
+					}
 					break;
 
 				case $row->wiki_inactive_exempt:
@@ -236,7 +240,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 							$options = $this->getConfig()->get( 'ManageWikiInactiveExemptReasonOptions' );
 							$reason = array_flip( $options )[$reason] ?? $reason;
 						}
-						$wiki['exempt-reason'] = $reason;
+						$wiki['exemptreason'] = $reason;
 					}
 					break;
 
@@ -292,11 +296,12 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => [
 					'category',
-					'closure',
-					'creation',
+					'closuredate',
+					'creationdate',
 					'description',
-					'deletion',
+					'deletiondate',
 					'exemptreason',
+					'inactivedate',
 					'languagecode',
 					'sitename',
 					'url',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -63,7 +63,14 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		}
 
 		if ( $language ) {
-			if ( !$this->languageNameUtils->isValidCode( $language ) ) {
+			$isLanguageInvalid = count(
+				array_filter(
+					$language,
+					fn ( string $code ): bool => !$this->languageNameUtils->isValidCode( $code )
+				)
+			) > 0;
+
+			if ( $isLanguageInvalid ) {
 				$encodedLanguage = $this->encodeParamName( 'language' );
 				$this->dieWithError(
 					[ 'apierror-invalidlang', $encodedLanguage ],

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -228,7 +228,12 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				case $row->wiki_inactive_exempt:
 					$wiki['inactive'] = 'exempt';
 					if ( in_array( 'exemptreason', $siteprop ) ) {
-						$wiki['exempt-reason'] = $row->wiki_inactive_exempt_reason;
+						$reason = $row->wiki_inactive_exempt_reason;
+						if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
+							$options = $this->getConfig()->get( 'ManageWikiInactiveExemptReasonOptions' );
+							$reason = $options[$reason] ?? $reason;
+						}
+						$wiki['exempt-reason'] = $reason;
 					}
 					break;
 

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -10,6 +10,7 @@ use MediaWiki\Api\ApiResult;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
 use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
+use Miraheze\CreateWiki\Services\CreateWikiValidator;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
 use Wikimedia\ParamValidator\ParamValidator;
 use Wikimedia\ParamValidator\TypeDef\IntegerDef;
@@ -21,6 +22,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		ApiQuery $query,
 		string $moduleName,
 		private readonly CreateWikiDatabaseUtils $databaseUtils,
+		private readonly CreateWikiValidator $validator,
 		private readonly ExtensionRegistry $extensionRegistry,
 		private readonly LanguageNameUtils $languageNameUtils
 	) {
@@ -162,17 +164,8 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			$wiki = [];
 
 			if ( in_array( 'url', $siteprop ) ) {
-				$url = $row->wiki_url;
-				if ( !$url ) {
-					$domain = $this->getConfig()->get( 'CreateWikiSubdomain' );
-					$subdomain = substr(
-						$row->wiki_dbname, 0,
-						-strlen( $this->getConfig()->get( 'CreateWikiDatabaseSuffix' ) )
-					);
-					$url = "https://$subdomain.$domain";
-				}
-
-				$wiki['url'] = $url;
+				$wiki['url'] = $row->wiki_url ?:
+					$this->validator->getValidUrl( $row->wiki_dbname );
 			}
 
 			$wiki['dbname'] = $row->wiki_dbname;

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -239,7 +239,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				],
 			],
 			'siteprop' => [
-				ParamValidator::PARAM_DEFAULT => 'category|dbname|languagecode|sitename|url',
+				ParamValidator::PARAM_DEFAULT => 'category|languagecode|sitename|url',
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => [
 					'category',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -80,15 +80,13 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		$this->addFieldsIf( 'wiki_creation', in_array( 'creation', $siteprop ) );
 		$this->addFieldsIf( 'wiki_closed_timestamp', in_array( 'closure', $siteprop ) );
 
-		$this->addFields(
-			[
-				'wiki_closed',
-				'wiki_deleted',
-				'wiki_inactive',
-				'wiki_locked',
-				'wiki_private',
-			]
-		);
+		$this->addFields( [
+			'wiki_closed',
+			'wiki_deleted',
+			'wiki_inactive',
+			'wiki_locked',
+			'wiki_private',
+		] );
 
 		$this->addOption( 'LIMIT', $limit );
 

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -6,6 +6,7 @@ use MediaWiki\Api\ApiBase;
 use MediaWiki\Api\ApiPageSet;
 use MediaWiki\Api\ApiQuery;
 use MediaWiki\Api\ApiQueryGeneratorBase;
+use MediaWiki\Api\ApiResult;
 use MediaWiki\Languages\LanguageNameUtils;
 use MediaWiki\Registration\ExtensionRegistry;
 use Miraheze\CreateWiki\Services\CreateWikiDatabaseUtils;
@@ -217,12 +218,17 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['locked'] = true;
 			}
 
-			$fit = $result->addValue( [ 'query', $this->getModuleName() ], $row->wiki_dbname, $wiki );
+			$fit = $result->addValue( [ 'query', $this->getModuleName(), 'wikis' ], $row->wiki_dbname, $wiki );
 			if ( !$fit ) {
 				$this->setContinueEnumParameter( 'offset', $offset + $count - 1 );
 				break;
 			}
 		}
+
+		$result->addValue(
+			[ 'query', $this->getModuleName() ], 'count', $count,
+			ApiResult::ADD_ON_TOP | ApiResult::NO_SIZE_CHECK
+		);
 	}
 
 	/** @inheritDoc */

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -93,13 +93,18 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			}
 
 			if ( in_array( 'active', $state ) ) {
-				$this->addWhere(
-					'wiki_closed = 0 AND wiki_deleted = 0 AND wiki_inactive = 0'
-				);
+				$this->addWhere( [
+					'wiki_closed' => 0,
+					'wiki_deleted' => 0,
+					'wiki_inactive' => 0,
+				] );
 			}
 
 			if ( in_array( 'open', $state ) ) {
-				$this->addWhere( 'wiki_closed = 0 AND wiki_deleted = 0' );
+				$this->addWhere( [
+					'wiki_closed' => 0,
+					'wiki_deleted' => 0,
+				] );
 			}
 
 			if ( in_array( 'locked', $state ) ) {
@@ -122,6 +127,11 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$this->addWhereFld( 'wiki_deleted', 1 );
 			}
 		}
+
+		$this->addWhereIf(
+			$this->getDB()->expr( 'wiki_url', '!=', null ),
+			$params['customurl']
+		);
 
 		$this->addFieldsIf( 'wiki_category', in_array( 'category', $siteprop ) );
 		$this->addFieldsIf( 'wiki_creation', in_array( 'creation', $siteprop ) );
@@ -257,6 +267,10 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			'category' => [
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => $this->getConfig()->get( 'CreateWikiCategories' ),
+			],
+			'customurl' => [
+				ParamValidator::PARAM_DEFAULT => false,
+				ParamValidator::PARAM_TYPE => 'boolean',
 			],
 			'language' => [
 				ParamValidator::PARAM_ISMULTI => true,

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -217,7 +217,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$wiki['locked'] = true;
 			}
 
-			$fit = $result->addValue( [ 'query', $this->getModuleName(), $row->wiki_dbname ], null, $wiki );
+			$fit = $result->addValue( [ 'query', $this->getModuleName() ], $row->wiki_dbname, $wiki );
 			if ( !$fit ) {
 				$this->setContinueEnumParameter( 'offset', $offset + $count - 1 );
 				break;

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -209,7 +209,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			],
 			'limit' => [
 				IntegerDef::PARAM_MIN => 1,
-				IntegerDef::PARAM_MAX => self::LIMIT_BIG1,
+				IntegerDef::PARAM_MAX => self::LIMIT_BIG2,
 				IntegerDef::PARAM_MAX2 => self::LIMIT_BIG2,
 				ParamValidator::PARAM_DEFAULT => self::LIMIT_BIG1,
 				ParamValidator::PARAM_TYPE => 'limit',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -86,6 +86,10 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				$this->addWhereFld( 'wiki_inactive', 1 );
 			}
 
+			if ( in_array( 'exempt', $state ) ) {
+				$this->addWhereFld( 'wiki_inactive_exempt', 1 );
+			}
+
 			if ( in_array( 'active', $state ) ) {
 				$this->addWhere(
 					'wiki_closed = 0 AND wiki_deleted = 0 AND wiki_inactive = 0'
@@ -126,11 +130,14 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		$this->addFieldsIf( 'wiki_closed_timestamp', in_array( 'closure', $siteprop ) );
 		$this->addFieldsIf( 'wiki_deleted_timestamp', in_array( 'deletion', $siteprop ) );
 
+		$this->addFieldsIf( 'wiki_inactive_exempt_reason', in_array( 'exemptreason', $siteprop ) );
+
 		$this->addFields( [
 			'wiki_closed',
 			'wiki_dbname',
 			'wiki_deleted',
 			'wiki_inactive',
+			'wiki_inactive_exempt',
 			'wiki_locked',
 			'wiki_private',
 		] );
@@ -218,6 +225,13 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 					$wiki['inactive'] = true;
 					break;
 
+				case $row->wiki_inactive_exempt:
+					$wiki['inactive'] = 'exempt';
+					if ( in_array( 'exemptreason', $siteprop ) ) {
+						$wiki['exempt-reason'] = $row->wiki_inactive_exempt_reason;
+					}
+					break;
+
 				default:
 					$wiki['active'] = true;
 			}
@@ -258,6 +272,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 					'active',
 					'closed',
 					'deleted',
+					'exempt',
 					'inactive',
 					'locked',
 					'open',
@@ -275,6 +290,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 					'creation',
 					'description',
 					'deletion',
+					'exemptreason',
 					'languagecode',
 					'sitename',
 					'url',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -173,18 +173,11 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 			}
 
 			$wiki = [];
+			$wiki['dbname'] = $row->wiki_dbname;
 
 			if ( in_array( 'url', $prop ) ) {
 				$wiki['url'] = $row->wiki_url ?:
 					$this->validator->getValidUrl( $row->wiki_dbname );
-			}
-
-			$wiki['dbname'] = $row->wiki_dbname;
-			if ( in_array( 'description', $prop ) ) {
-				if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
-					$manageWikiSettings = new ManageWikiSettings( $wiki['dbname'] );
-					$wiki['description'] = $manageWikiSettings->list( 'wgWikiDiscoverDescription' );
-				}
 			}
 
 			if ( in_array( 'sitename', $prop ) ) {
@@ -197,6 +190,13 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 
 			if ( in_array( 'languagecode', $prop ) ) {
 				$wiki['languagecode'] = $row->wiki_language;
+			}
+
+			if ( in_array( 'description', $prop ) ) {
+				if ( $this->extensionRegistry->isLoaded( 'ManageWiki' ) ) {
+					$manageWikiSettings = new ManageWikiSettings( $wiki['dbname'] );
+					$wiki['description'] = $manageWikiSettings->list( 'wgWikiDiscoverDescription' );
+				}
 			}
 
 			if ( in_array( 'creationdate', $prop ) ) {

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -227,7 +227,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				],
 			],
 			'siteprop' => [
-				ParamValidator::PARAM_DEFAULT => 'url|dbname|sitename|languagecode',
+				ParamValidator::PARAM_DEFAULT => 'category|dbname|languagecode|sitename|url',
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => [
 					'category',

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -209,7 +209,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => $this->getConfig()->get( 'CreateWikiCategories' ),
 			],
-			'languagecode' => [
+			'language' => [
 				ParamValidator::PARAM_ISMULTI => true,
 				ParamValidator::PARAM_TYPE => 'string',
 			],

--- a/includes/Api/ApiQueryWikiDiscover.php
+++ b/includes/Api/ApiQueryWikiDiscover.php
@@ -52,7 +52,7 @@ class ApiQueryWikiDiscover extends ApiQueryGeneratorBase {
 		$wikis = $params['wikis'];
 
 		$this->addTables( 'cw_wikis' );
-		
+
 		if ( $category ) {
 			$this->addWhereFld( 'wiki_category', $category );
 		}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -6,7 +6,7 @@ use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 
-class WikiDiscover {
+class Hooks {
 
 	/**
 	 * @param Parser $parser

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -35,7 +35,7 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	}
 
 	private function insertWiki(): void {
-		$databaseUtils = $this->getServiceContainer()->get( 'CreateWikiDatabaseUtils' )
+		$databaseUtils = $this->getServiceContainer()->get( 'CreateWikiDatabaseUtils' );
 		$dbw = $databaseUtils->getGlobalPrimaryDB();
 		$dbw->newInsertQueryBuilder()
 			->insertInto( 'cw_wikis' )

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -28,7 +28,7 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 		$this->assertArrayHasKey( 'query', $data );
 		$this->assertArrayHasKey( 'wikidiscover', $data['query'] );
 		$this->assertNotCount( 0, $data['query']['wikidiscover'], 'wikidiscover API response should not be empty' );
-		foreach ( $data['query']['wikidiscover'] as $wiki ) {
+		foreach ( $data['query']['wikidiscover'] as _ => $wiki ) {
 			$this->assertArrayHasKey( 'dbname', $wiki );
 			$this->assertArrayHasKey( 'sitename', $wiki );
 		}

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -4,7 +4,6 @@ namespace Miraheze\WikiDiscover\Tests\Api;
 
 use MediaWiki\MainConfigNames;
 use MediaWiki\Tests\Api\ApiTestCase;
-use MediaWiki\WikiMap\WikiMap;
 
 /**
  * @group WikiDiscover

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -27,11 +27,12 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 			]
 		);
 
+		var_dump( $data );
+
 		$this->assertArrayHasKey( 'query', $data );
 		$this->assertArrayHasKey( 'wikidiscover', $data['query'] );
 		$this->assertNotCount( 0, $data['query']['wikidiscover'], 'wikidiscover API response should not be empty' );
 		foreach ( $data['query']['wikidiscover'] as $wiki ) {
-			var_dump( $wiki );
 			$this->assertArrayHasKey( 'dbname', $wiki );
 			$this->assertArrayHasKey( 'sitename', $wiki );
 		}

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -21,7 +21,7 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	 */
 	public function testQueryWikiDiscover() {
 		$this->overrideConfigValue( MainConfigNames::VirtualDomainsMapping, [
-			'virtual-createwiki' => [ 'db' => WikiMap::getCurrentWikiId() ],
+			'virtual-createwiki' => [ 'db' => 'wikidb' ],
 		] );
 
 		[ $data ] = $this->doApiRequest( [

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -20,17 +20,18 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	 */
 	public function testQueryWikiDiscover(): void {
 		$this->insertWiki();
-		[ $data ] = $this->doApiRequest( [
+		[ $response ] = $this->doApiRequest( [
 			'action' => 'query',
 			'list' => 'wikidiscover',
 		] );
 
-		$this->assertArrayHasKey( 'query', $data );
-		$this->assertArrayHasKey( 'wikidiscover', $data['query'] );
-		$this->assertNotCount( 0, $data['query']['wikidiscover'], 'wikidiscover API response should not be empty' );
-		foreach ( $data['query']['wikidiscover'] as _ => $wiki ) {
-			$this->assertArrayHasKey( 'dbname', $wiki );
-			$this->assertArrayHasKey( 'sitename', $wiki );
+		$this->assertArrayHasKey( 'query', $response );
+		$this->assertArrayHasKey( 'wikidiscover', $response['query'] );
+		$this->assertNotCount( 0, $response['query']['wikidiscover'], 'wikidiscover API response should not be empty' );
+		foreach ( $response['query']['wikidiscover'] as $wiki => $data ) {
+			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover'] );
+			$this->assertArrayHasKey( 'dbname', $data );
+			$this->assertArrayHasKey( 'sitename', $data );
 		}
 	}
 

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -29,7 +29,10 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 			'list' => 'wikidiscover',
 		] );
 
-		var_dump( $data );
+		var_dump(
+			$this->getServiceContainer()->get( 'CreateWikiDatabaseUtils' )
+				->getGlobalReplicaDB()->getDomainID()
+		);
 
 		$this->assertArrayHasKey( 'query', $data );
 		$this->assertArrayHasKey( 'wikidiscover', $data['query'] );

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -27,8 +27,9 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 
 		$this->assertArrayHasKey( 'query', $response );
 		$this->assertArrayHasKey( 'wikidiscover', $response['query'] );
-		$this->assertNotCount( 0, $response['query']['wikidiscover'], 'wikidiscover API response should not be empty' );
-		foreach ( $response['query']['wikidiscover'] as $wiki => $data ) {
+		$this->assertArrayHasKey( 'count', $response['query']['wikidiscover'] );
+		$this->assertNotCount( 0, $response['query']['wikidiscover']['wikis'], 'wikidiscover API response should not be empty' );
+		foreach ( $response['query']['wikidiscover']['wikis'] as $wiki => $data ) {
 			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover'] );
 			$this->assertArrayHasKey( 'dbname', $data );
 			$this->assertArrayHasKey( 'sitename', $data );

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -31,7 +31,7 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 		$this->assertNotCount( 0, $response['query']['wikidiscover']['wikis'], 'wikidiscover API response should not be empty' );
 
 		foreach ( $response['query']['wikidiscover']['wikis'] as $wiki => $data ) {
-			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover'] );
+			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover']['wikis'] );
 			$this->assertArrayHasKey( 'dbname', $data );
 			$this->assertArrayHasKey( 'sitename', $data );
 		}

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -16,7 +16,6 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	/**
 	 * @covers ::__construct
 	 * @covers ::execute
-	 * @covers ::run
 	 */
 	public function testQueryWikiDiscover(): void {
 		$this->insertWiki();

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -24,13 +24,10 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 			'list' => 'wikidiscover',
 		] );
 
-		$this->assertArrayHasKey( 'query', $response );
-		$this->assertArrayHasKey( 'wikidiscover', $response['query'] );
 		$this->assertArrayHasKey( 'count', $response['query']['wikidiscover'] );
 		$this->assertNotCount( 0, $response['query']['wikidiscover']['wikis'], 'wikidiscover API response should not be empty' );
 
 		foreach ( $response['query']['wikidiscover']['wikis'] as $wiki => $data ) {
-			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover']['wikis'] );
 			$this->assertArrayHasKey( 'dbname', $data );
 			$this->assertArrayHasKey( 'sitename', $data );
 		}

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -2,7 +2,9 @@
 
 namespace Miraheze\WikiDiscover\Tests\Api;
 
+use MediaWiki\MainConfigNames;
 use MediaWiki\Tests\Api\ApiTestCase;
+use MediaWiki\WikiMap\WikiMap;
 
 /**
  * @group WikiDiscover
@@ -18,11 +20,13 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	 * @covers ::run
 	 */
 	public function testQueryWikiDiscover() {
+		$this->overrideConfigValue( MainConfigNames::VirtualDomainsMapping, [
+			'virtual-createwiki' => [ 'db' => WikiMap::getCurrentWikiId() ],
+		] );
+
 		[ $data ] = $this->doApiRequest( [
 			'action' => 'query',
 			'list' => 'wikidiscover',
-			'wdstate' => 'active',
-			'wdsiteprop' => 'dbname|sitename'
 		] );
 
 		var_dump( $data );

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -18,14 +18,12 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 	 * @covers ::run
 	 */
 	public function testQueryWikiDiscover() {
-		[ $data ] = $this->doApiRequest(
-			[
-				'action' => 'query',
-				'list' => 'wikidiscover',
-				'wdstate' => 'active',
-				'wdsiteprop' => 'dbname|sitename'
-			]
-		);
+		[ $data ] = $this->doApiRequest( [
+			'action' => 'query',
+			'list' => 'wikidiscover',
+			'wdstate' => 'active',
+			'wdsiteprop' => 'dbname|sitename'
+		] );
 
 		var_dump( $data );
 

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -29,6 +29,7 @@ class ApiQueryWikiDiscoverTest extends ApiTestCase {
 		$this->assertArrayHasKey( 'wikidiscover', $response['query'] );
 		$this->assertArrayHasKey( 'count', $response['query']['wikidiscover'] );
 		$this->assertNotCount( 0, $response['query']['wikidiscover']['wikis'], 'wikidiscover API response should not be empty' );
+
 		foreach ( $response['query']['wikidiscover']['wikis'] as $wiki => $data ) {
 			$this->assertArrayHasKey( $wiki, $response['query']['wikidiscover'] );
 			$this->assertArrayHasKey( 'dbname', $data );

--- a/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
+++ b/tests/phpunit/Api/ApiQueryWikiDiscoverTest.php
@@ -2,7 +2,6 @@
 
 namespace Miraheze\WikiDiscover\Tests\Api;
 
-use MediaWiki\MainConfigNames;
 use MediaWiki\Tests\Api\ApiTestCase;
 use MediaWiki\WikiMap\WikiMap;
 


### PR DESCRIPTION
The current API is severely limited and unreliable. It lacks a **continue** parameter, making it impossible to list all wikis. Additionally, both **siteprop** and **state** fail to provide accurate data, and the limit applies to all results rather than just the displayed ones, further reducing the number of retrievable entries.

This update completely overhauls the API, addressing these issues and introducing several improvements:
- **Accurate Result Count:** The total count of results is now displayed.
- **Enhanced Filtering:** Supports filtering by **language code** and **category**.
- **Wiki Deletion Date:** Displays the deletion date for removed wikis.
- **Category Display:** Includes category information for wikis.
- **Description Display:** Properly shows wiki descriptions.
- **Inactivity Exemptions:** Adds the ability to show information on inactivity exemptions.
- **Offset Parameter:** Adds an **offset** parameter that functions similarly to the missing **continue** parameter, allowing you to paginate through results more efficiently.

Additionally, this refactor allows us to remove all expensive helper methods from the **WikiDiscover** class, leaving only essential hooks. As a result, the class has been renamed to **Hooks** for clarity.

### Breaking Change:
This update introduces significant changes to the API, making it **backward incompatible**. Any existing usage of the previous API will need to be updated to accommodate these new features and changes.

---

*PR description generated by .GitHub Copilot AI:*
### Changes and New Parameters in `ApiQueryWikiDiscover`

The `ApiQueryWikiDiscover` class introduces several changes and new parameters compared to the original `ApiWikiDiscover` class. Here is a detailed comparison and description of the changes:

#### File Structure Changes

```diff
- includes/Api/ApiWikiDiscover.php (removed)
+ includes/Api/ApiQueryWikiDiscover.php (added)
```

#### Major Changes

1. **Class Name and Inheritance**:
   - The original class `ApiWikiDiscover` extended `ApiBase`.
   - The new class `ApiQueryWikiDiscover` extends `ApiQueryBase`.

2. **Constructor and Dependency Injection**:
   - The new class uses dependency injection for services like `CreateWikiDatabaseUtils`, `CreateWikiValidator`, `ExtensionRegistry`, and `LanguageNameUtils`.
   - The constructor of `ApiQueryWikiDiscover` takes additional parameters for these services.

3. **Method Changes**:
   - The `execute` method in the original class has been replaced with `executeGenerator` and `run` methods in the new class.
   - The new class includes additional methods like `getCacheMode`, `getDB`, and `getAllowedParams`.

4. **Parameter Handling**:
   - The new class uses `ParamValidator` more extensively to define allowed parameters and their types.
   - Additional parameters have been introduced to support more detailed querying capabilities.

#### New and Renamed Parameters

1. **New Parameters**:
   - `category`: Filters wikis by the CreateWiki defined category.
   - `customurl`: Filters wikis based on whether they have a custom URL defined by CreateWiki.
   - `language`: Filters wikis by the CreateWiki defined language code.
   - `prop`: Specifies the information to return about a defined wiki.
   - `state`: Filters wikis by their state (e.g., active, closed, deleted, etc.).
   - `wikis`: Specifies a list of specific wikis to query.

2. **Renamed Parameters**:
   - `siteprop` in the original class has been replaced with `prop` in the new class.
   - The `state` parameter has been expanded to include more detailed states.

#### Detailed Description of New Parameters

- **category**: 
  - Type: `string[]`
  - Description: Filters the results to include only wikis in the specified categories.
  
- **customurl**: 
  - Type: `boolean`
  - Default: `false`
  - Description: Filters the results to include only wikis that have a custom URL.
  
- **language**: 
  - Type: `string[]`
  - Description: Filters the results to include only wikis with the specified language codes.
  
- **prop**: 
  - Type: `string[]`
  - Default: `['category', 'languagecode', 'sitename', 'url']`
  - Description: Specifies which properties to include in the results. Possible values include `category`, `closuredate`, `creationdate`, `description`, `deletiondate`,
  - , `exemptreason`, `inactivedate`, `languagecode`, `sitename`, and `url`.
  
- **state**: 
  - Type: `string[]`
  - Default: `['all']`
  - Description: Filters the results to include only wikis with the specified states. Possible values include `all`, `active`, `closed`, `deleted`, `exempt`, `inactive`, `locked`, `open`, `private`, `public`, and `unlocked`.
  
- **wikis**: 
  - Type: `string[]`
  - Description: Filters the results to include only the specified wikis.

These changes and new parameters enhance the querying capabilities of the `WikiDiscover` extension, allowing for more detailed and flexible queries.