### PR TITLE
Add WikiDiscoverDescriptionMaxLength

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -50,6 +50,11 @@
 		]
 	},
 	"config": {
+		"WikiDiscoverDescriptionMaxLength": {
+			"description": "Int. The maxmimum length of a wiki description.",
+			"public": true,
+			"value": false
+		},
 		"WikiDiscoverListPrivateWikis": {
 			"description": "Whether or not to include showing private wikis on Special:WikiDiscover.",
 			"public": true,


### PR DESCRIPTION
Original commit: https://github.com/WikiForge/WikiDiscover/commit/a07c1669c0055e58019e10ca0c40ce6497479fb7
Original commit description: "Useful to control the max length of a description, evidently"
Original commit author: @AgentIsai