### PR TITLE
Improve Special:RandomWiki

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -12,7 +12,7 @@
 	"wikidiscover-desc": "Allows [[Special:WikiDiscover|discovering wikis]] on a wiki farm with [[Special:CreateWiki|CreateWiki]].",
 	"wikidiscover-table-category": "Category",
 	"wikidiscover-table-description": "Description",
-	"wikidiscover-table-established": "Established", 
+	"wikidiscover-table-established": "Established",
 	"wikidiscover-table-language": "Language",
 	"wikidiscover-table-state": "State",
 	"wikidiscover-table-visibility": "Visibility",

--- a/includes/SpecialRandomWiki.php
+++ b/includes/SpecialRandomWiki.php
@@ -37,12 +37,16 @@ class SpecialRandomWiki extends SpecialPage {
 			],
 		];
 
-        if ( $this->config->get( 'CreateWikiUseInactiveWikis' ) ) {
-            $formDescriptor['inactive'] = [
+		if ( $this->config->get( 'CreateWikiUseInactiveWikis' ) ) {
+			$formDescriptor['inactive'] = [
 				'type' => 'select',
 				'name' => 'inactive',
 				'label-message' => 'wikidiscover-table-state',
-				'options' => [ '(any)' => 'any', 'active' => 'active', 'inactive' => 'inactive' ],
+				'options' => [
+					'(any)' => 'any',
+					'active' => 'active',
+					'inactive' => 'inactive',
+				],
 				'default' => 'any',
 			];
 		}

--- a/includes/SpecialRandomWiki.php
+++ b/includes/SpecialRandomWiki.php
@@ -61,7 +61,11 @@ class SpecialRandomWiki extends SpecialPage {
 	public function redirectWiki( $formData ) {
 		$randomwiki = WikiDiscoverRandom::randomWiki(  $formData['inactive'], $formData['category'], $formData['language'] );
 
-		header( "Location: https://" . substr( $randomwiki->wiki_dbname, 0, -4 ) . ".{$this->config->get( 'CreateWikiSubdomain' )}/" );
+		if ( $randomwiki->wiki_url ) {
+			header( "Location: https://" . $randomwiki->wiki_url . "/" );
+		} else {
+			header( "Location: https://" . substr( $randomwiki->wiki_dbname, 0, -4 ) . ".{$this->config->get( 'CreateWikiSubdomain' )}/" );
+		}
 
 		return true;
 	}

--- a/includes/SpecialRandomWiki.php
+++ b/includes/SpecialRandomWiki.php
@@ -59,7 +59,7 @@ class SpecialRandomWiki extends SpecialPage {
 	 * @return bool
 	 */
 	public function redirectWiki( $formData ) {
-		$randomwiki = WikiDiscoverRandom::randomWiki(  $formData['inactive'], $formData['category'], $formData['language'] );
+		$randomwiki = WikiDiscoverRandom::randomWiki( $formData['inactive'], $formData['category'], $formData['language'] );
 
 		if ( $randomwiki->wiki_url ) {
 			header( "Location: https://" . $randomwiki->wiki_url . "/" );

--- a/includes/SpecialRandomWiki.php
+++ b/includes/SpecialRandomWiki.php
@@ -35,6 +35,16 @@ class SpecialRandomWiki extends SpecialPage {
 			],
 		];
 
+        if ( $this->config->get( 'CreateWikiUseInactiveWikis' ) ) {
+            $formDescriptor['inactive'] = [
+				'type' => 'select',
+				'name' => 'inactive',
+				'label-message' => 'wikidiscover-table-state',
+				'options' => [ '(any)' => 'any', 'active' => 'active', 'inactive' => 'inactive' ],
+				'default' => 'any',
+			];
+		}
+
 		$htmlForm = HTMLForm::factory( 'ooui', $formDescriptor, $this->getContext() );
 		$htmlForm->setSubmitCallback( [ $this, 'redirectWiki' ] )->setMethod( 'post' )->prepareForm()->show();
 	}
@@ -49,7 +59,7 @@ class SpecialRandomWiki extends SpecialPage {
 	 * @return bool
 	 */
 	public function redirectWiki( $formData ) {
-		$randomwiki = WikiDiscoverRandom::randomWiki( 0, $category = $formData['category'], $formData['language'] );
+		$randomwiki = WikiDiscoverRandom::randomWiki(  $formData['inactive'], $formData['category'], $formData['language'] );
 
 		header( "Location: https://" . substr( $randomwiki->wiki_dbname, 0, -4 ) . ".{$this->config->get( 'CreateWikiSubdomain' )}/" );
 

--- a/includes/WikiDiscoverRandom.php
+++ b/includes/WikiDiscoverRandom.php
@@ -51,7 +51,7 @@ class WikiDiscoverRandom {
 			->getMaintenanceConnectionRef( DB_REPLICA, [], $config->get( 'CreateWikiDatabase' ) );
 
 		/* MySQL is ever the outlier */
-		$random_function = $config->get( 'DBtype' ) === 'mysql' ? 'RAND()' : 'random()';
+		$random_function = $dbr->getType() === 'mysql' ? 'RAND()' : 'random()';
 
 		return $dbr->selectRow(
 			'cw_wikis',

--- a/includes/WikiDiscoverRandom.php
+++ b/includes/WikiDiscoverRandom.php
@@ -50,16 +50,15 @@ class WikiDiscoverRandom {
 		$dbr = $lbFactory->getMainLB( $config->get( 'CreateWikiDatabase' ) )
 			->getMaintenanceConnectionRef( DB_REPLICA, [], $config->get( 'CreateWikiDatabase' ) );
 
-		$possiblewikis = $dbr->selectFieldValues( 'cw_wikis', 'wiki_dbname', $conds, __METHOD__ );
+		/* MySQL is ever the outlier */
+		$random_function = $config->get( 'DBtype' ) === 'mysql' ? 'RAND()' : 'random()';
 
-		$randwiki = $possiblewikis[array_rand( $possiblewikis )];
+		return $dbr->selectRow(
+			'cw_wikis',
+			[ 'wiki_dbname', 'wiki_url' ],
+			__METHOD__,
+			[ 'ORDER BY' => $random_function, 'LIMIT' => 1]
+		);
 
-		$fields = [];
-
-		if ( $config->get( 'CreateWikiUseInactiveWikis' ) ) {
-			$fields[] = 'wiki_inactive';
-		}
-
-		return $dbr->selectRow( 'cw_wikis', array_merge( [ 'wiki_dbname', 'wiki_sitename', 'wiki_language', 'wiki_category' ], $fields ), [ 'wiki_dbname' => $randwiki ], __METHOD__ );
 	}
 }

--- a/includes/WikiDiscoverRandom.php
+++ b/includes/WikiDiscoverRandom.php
@@ -24,12 +24,14 @@ class WikiDiscoverRandom {
 
 		if ( $config->get( 'CreateWikiUseInactiveWikis' ) && $state === 'inactive' ) {
 			$conditions['wiki_inactive'] = 1;
-		} elseif ( $config->get( 'CreateWikiUseClosedWikis' ) && $state === 'closed' ) {
-			$conditions['wiki_closed'] = 1;
-		} elseif ( $config->get( 'CreateWikiUseClosedWikis' ) && $state === 'open' ) {
-			$conditions['wiki_closed'] = 0;
+		} elseif ( $config->get( 'CreateWikiUseInactiveWikis' ) && $state === 'active' ) {
+			$conditions['wiki_inactive'] = 0;
 		}
 
+		/* Never randomly offer closed or private wikis */
+		if ( $config->get( 'CreateWikiUseClosedWikis' ) ) {
+			$conditions['wiki_closed'] = 0;
+		}
 		if ( $config->get( 'CreateWikiUsePrivateWikis' ) ) {
 			$conditions['wiki_private'] = 0;
 		}
@@ -53,16 +55,9 @@ class WikiDiscoverRandom {
 		$randwiki = $possiblewikis[array_rand( $possiblewikis )];
 
 		$fields = [];
-		if ( $config->get( 'CreateWikiUseClosedWikis' ) ) {
-			$fields[] = 'wiki_closed';
-		}
 
 		if ( $config->get( 'CreateWikiUseInactiveWikis' ) ) {
 			$fields[] = 'wiki_inactive';
-		}
-
-		if ( $config->get( 'CreateWikiUsePrivateWikis' ) ) {
-			$fields[] = 'wiki_private';
 		}
 
 		return $dbr->selectRow( 'cw_wikis', array_merge( [ 'wiki_dbname', 'wiki_sitename', 'wiki_language', 'wiki_category' ], $fields ), [ 'wiki_dbname' => $randwiki ], __METHOD__ );

--- a/includes/WikiDiscoverRandom.php
+++ b/includes/WikiDiscoverRandom.php
@@ -57,7 +57,7 @@ class WikiDiscoverRandom {
 			'cw_wikis',
 			[ 'wiki_dbname', 'wiki_url' ],
 			__METHOD__,
-			[ 'ORDER BY' => $random_function, 'LIMIT' => 1]
+			[ 'ORDER BY' => $random_function, 'LIMIT' => 1 ]
 		);
 
 	}


### PR DESCRIPTION
This does three main things:

- Prevent being sent to a closed wiki
- Add an inactive wiki switch in the front-end
- Do random selection in the DB to save a query and use less data (this will be a little slower than Special:RandomPage's method, but on the size of the cw_wikis table less likely to matter)

Closes T11683