### PR TITLE
Use 'wiki' group

### DIFF
--- a/includes/Specials/SpecialRandomWiki.php
+++ b/includes/Specials/SpecialRandomWiki.php
@@ -133,6 +133,6 @@ class SpecialRandomWiki extends SpecialPage {
 
 	/** @inheritDoc */
 	protected function getGroupName(): string {
-		return 'wikimanage';
+		return 'wiki';
 	}
 }

--- a/includes/Specials/SpecialWikiDiscover.php
+++ b/includes/Specials/SpecialWikiDiscover.php
@@ -127,6 +127,6 @@ class SpecialWikiDiscover extends SpecialPage {
 
 	/** @inheritDoc */
 	protected function getGroupName(): string {
-		return 'wikimanage';
+		return 'wiki';
 	}
 }


### PR DESCRIPTION
Factoring out wikimanage because that means extensions rely on MirahezeMagic for the i18n and we dont want to copy rhe i18n to numerous extensions.